### PR TITLE
基本的预取实验

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1,15 +1,20 @@
+#include <ctime>
 #include <cerrno>
 #include <cstdio>
+#include <cstdint>
+#include <cstring>
+#include <cstdlib>
 #include <cstddef>
 #include <cassert>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 #include <sys/prctl.h>
 #include <sys/syscall.h>
+#include <fcntl.h>
 #include <unistd.h>
-#include <linux/kernel.h>
-#include <sys/mman.h>
-#include <stdlib.h>
-#include <cstring>
 #include <pthread.h>
+#include <linux/kernel.h>
 
 #define likely(x) __builtin_expect(!!(x), 1)
 #define unlikely(x) __builtin_expect(!!(x), 0)
@@ -18,8 +23,11 @@
 #define PAGE_SIZE 4096
 #define BUF_SIZE PAGE_SIZE
 
+#define ASYNC_CMD_PREFETCH 0
+
 typedef struct {
-	int x, y;
+	int cmd;
+	void *addr;
 } queue_elem_t;
 
 #define QUEUE_LEN ((BUF_SIZE - 3 * sizeof(int)) / sizeof(queue_elem_t))
@@ -66,23 +74,96 @@ void *thread_call(void *ptr) {
 	return NULL;
 }
 
-int main() {
-	void *ptr;
-	posix_memalign(&ptr, PAGE_SIZE, PAGE_SIZE);
-	mlock(ptr, PAGE_SIZE);
-	memset(ptr, 0, PAGE_SIZE);
+typedef void *async_handle_t;
+
+void async_init(async_handle_t *handle) {
+	posix_memalign(handle, PAGE_SIZE, PAGE_SIZE);
+	mlock(*handle, PAGE_SIZE);
+	memset(*handle, 0, PAGE_SIZE);
 	pthread_t th;
-	pthread_create(&th, NULL, thread_call, ptr);
+	pthread_create(&th, NULL, thread_call, *handle);
 	pthread_detach(th);
+}
 
-	AsyncQueue *q = (AsyncQueue *)ptr;
-	enqueue(q, queue_elem_t{1, 2});
-	enqueue(q, queue_elem_t{2, 5});
-	enqueue(q, queue_elem_t{5, 2});
-	enqueue(q, queue_elem_t{6, 2});
+void async_prefetch(async_handle_t handle, void *addr) {
+	AsyncQueue *q = (AsyncQueue *)handle;
+	enqueue(q, queue_elem_t{ASYNC_CMD_PREFETCH, addr});
+}
 
-	sleep(5);
+const int MODE_NAVIE = 0;
+const int MODE_ASYNC_PREFETCH = 1;
+const int MODE_SYNC_PREFETCH = 2;
 
+const int length = 1024 * 1024 * 1024;
+const int n_op = 1000000;
+int op_addr[n_op];
+
+// some arbitrary operations
+int op(int x) {
+	for (int i = 0; i < 100; i++)
+		x = (x * 513 + 912747) % 1037593;
+	return x;
+}
+
+void print_help(const char *name) {
+	printf("Usage: %s <naive|sync-prefetch|async-prefetch>\n", name);
+}
+
+int main(int argc, char **argv) {
+	int mode;
+	if (argc != 2) {
+		print_help(argv[0]);
+		exit(1);
+	}
+	if (strcmp(argv[1], "naive") == 0)
+		mode = MODE_NAVIE;
+	else if (strcmp(argv[1], "async-prefetch") == 0)
+		mode = MODE_ASYNC_PREFETCH;
+	else if (strcmp(argv[1], "sync-prefetch") == 0)
+		mode = MODE_SYNC_PREFETCH;
+	else {
+		print_help(argv[0]);
+		exit(1);
+	}
+
+	srand(0);
+	for (int i = 0; i < n_op; i++)
+		op_addr[i] = rand() % length;
+
+	async_handle_t handle;
+	async_init(&handle);
+
+
+	int fd = open("data", O_RDWR);
+	uint8_t *buff = (uint8_t*)mmap(NULL, length, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+
+	clock_t t0 = clock();
+	switch (mode) {
+	case MODE_NAVIE:
+		for (int i = 0; i < n_op; i++)
+			buff[op_addr[i]] = (uint8_t)op(buff[op_addr[i]]);
+		break;
+	case MODE_SYNC_PREFETCH:
+		for (int i = 0; i < n_op; i++) {
+			uint8_t x = buff[op_addr[i]];
+			if (i + 1 < n_op)
+				__builtin_prefetch(&buff[op_addr[i + 1]]);
+			buff[op_addr[i]] = (uint8_t)op(x);
+		}
+		break;
+	case MODE_ASYNC_PREFETCH:
+		for (int i = 0; i < n_op; i++) {
+			uint8_t x = buff[op_addr[i]];
+			if (i + 1 < n_op)
+				async_prefetch(handle, &buff[op_addr[i + 1]]);
+			buff[op_addr[i]] = (uint8_t)op(x);
+		}
+		break;
+	}
+	clock_t t1 = clock();
+	printf("Time = %fs\n", (double)(t1 - t0) / CLOCKS_PER_SEC);
+
+	close(fd);
 	return 0;
 }
 


### PR DESCRIPTION
测试预取性能的用户态程序。

测试内容：

将 1GB 的文件映射到内存，对其进行 10^6 次随机的 读取-修改-写回。有三种模式：naive（不预取）、async-prefetch（用我们的内核进行预取）、sync-prefetch（对照组，用`__builtin_prefetch`进行预取，这种方式理应不比 naive 快）。

测试方法：

**将虚拟机的内存大小调到 1GB**，然后执行如下命令：

```sh
dd bs=1024 count=1048576 if=/dev/zero of=./data && ./main <mode>
```

其中`<mode>`可以是`naive`、`async-prefetch`或`sync-prefetch`。程序会输出不含初始化的实际运行时间。

测试结果：在我的平台上，async-prefetch 能显著快于 naive，大致能从 260s 降低到 200s，符合预期。

有一个待解决问题：用 `apt-get install time`可以装一个`/usr/bin/time`（不是 shell 里带的那个 time），通过`/usr/bin/time -v`可以查看统计的 page fault 次数。其中需要 I/O 的 major page fault 只降低了一点，例如 275248 降到 263619。我 prefetch 的代码理应是绕过了这个计数器的（计数器在`arch/x86/mm/fault.c`的`__do_page_fault`里最下面）。

@otowa-kotori